### PR TITLE
fix(project): Bump core SDK version again to fix class cast issue

### DIFF
--- a/modules/container-registry/src/test/java/com/ibm/cloud/container_registry/container_registry/v1/ContainerRegistryIT.java
+++ b/modules/container-registry/src/test/java/com/ibm/cloud/container_registry/container_registry/v1/ContainerRegistryIT.java
@@ -68,7 +68,6 @@ import com.ibm.cloud.sdk.core.http.Response;
 import com.ibm.cloud.sdk.core.service.exception.ServiceResponseException;
 import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
 import com.ibm.cloud.sdk.core.util.CredentialUtils;
-import com.google.gson.internal.LazilyParsedNumber;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/modules/container-registry/src/test/java/com/ibm/cloud/container_registry/container_registry/v1/ContainerRegistryIT.java
+++ b/modules/container-registry/src/test/java/com/ibm/cloud/container_registry/container_registry/v1/ContainerRegistryIT.java
@@ -68,6 +68,7 @@ import com.ibm.cloud.sdk.core.http.Response;
 import com.ibm.cloud.sdk.core.service.exception.ServiceResponseException;
 import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
 import com.ibm.cloud.sdk.core.util.CredentialUtils;
+import com.google.gson.internal.LazilyParsedNumber;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -396,7 +397,7 @@ public class ContainerRegistryIT extends SdkIntegrationTestBase {
 
       assertNotNull(resultResult);
 
-      double version = (double)(resultResult.get("schemaVersion"));
+      double version = ((Number)resultResult.get("schemaVersion")).doubleValue();
       double expected = 2;
       assertEquals(version, expected);
     } catch (ServiceResponseException e) {

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
             of the SDK generator used to generate your SDK code.
             See this link for details: https://github.ibm.com/CloudEngineering/openapi-sdkgen/wiki/Compatibility-Chart
         -->
-        <sdk-core-version>9.13.4</sdk-core-version>
+        <sdk-core-version>9.14.1</sdk-core-version>
 
         <!-- >>> Replace this with the name of your SDK's github repository -->
         <git-repository-name>container-registry-java-sdk</git-repository-name>


### PR DESCRIPTION
Signed-off-by: James Hart <jhart@uk.ibm.com>

## PR summary
The previous release introduced an issue with how the Integration Tests were retrieving the Schema version on GetImageManifest.
This PR consumes a newer version of the core SDK, which fixes the regression. It also improves the test case as advised by the SDK core team.

**Fixes:** <! -- link to issue -->

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [x] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?  
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->